### PR TITLE
Card debugging

### DIFF
--- a/code/controllers/subsystem/tcgsetup.dm
+++ b/code/controllers/subsystem/tcgsetup.dm
@@ -1,5 +1,6 @@
 #define CARD_FILES list("templates", "set_one", "set_two")
 #define CARD_DIRECTORY "strings/tcg"
+#define CARD_PACKS list(/obj/item/cardpack/series_one, /obj/item/cardpack/resin)
 SUBSYSTEM_DEF(trading_card_game)
 	name = "Trading Card Game"
 	flags = SS_NO_FIRE

--- a/code/game/objects/items/tcg/tcg.dm
+++ b/code/game/objects/items/tcg/tcg.dm
@@ -91,7 +91,9 @@ var/list/cardTypeLookup = list("name" = 0,
 	icon_state = "cardback_nt"
 	var/series = "MEME" //Mirrors the card series.
 	var/contains_coin = -1 //Chance of the pack having a coin in it.
+	///The amount of cards each pack contains
 	var/card_count = 6
+	///The guarenteed rarity, if none set this to 0
 	var/guar_rarity = 4
 	var/list/rarityTable = list(1,
 							2,
@@ -299,15 +301,18 @@ var/list/cardTypeLookup = list("name" = 0,
 			return toReturn[1]
 	return ""
 
+///Loads all the card files
 /proc/loadAllCardFiles(cardFiles, directory)
 	var/list/templates = list()
 	for(var/cardFile in cardFiles)
 		loadCardFile(cardFile, directory, templates)
 
+///Prints all the cards names
 /proc/printAllCards()
 	for(var/card in GLOB.card_list)
 		message_admins("[GLOB.card_list[card].name]")
 
+///Checks the passed type list for missing raritys, or raritys out of bounds
 /proc/checkCardpacks(cardPackList)
 	for(var/cardPack in cardPackList)
 		var/obj/item/cardpack/pack = new cardPack()
@@ -330,6 +335,7 @@ var/list/cardTypeLookup = list("name" = 0,
 				message_admins("[pack.type] does not have the required rarity [rarityCheck[I]] in the range 1 to [pack.rarityTable.len]")
 		qdel(pack)
 
+///Used to test open a large amount of cardpacks
 /proc/checkCardDistribution(cardPack, batchSize, batchCount)
 	var/totalCards = 0
 	//Gotta make this look like an associated list so the implicit "does this exist" checks work proper later
@@ -347,11 +353,12 @@ var/list/cardTypeLookup = list("name" = 0,
 	message_admins(toSend)
 	qdel(pack)
 
-
+///Reloads all card files
 /proc/reloadAllCardFiles(cardFiles, directory)
 	GLOB.card_list = list()
 	loadAllCardFiles(cardFiles, directory)
 
+///Loads a card file and turns its contents into card datums using the currently loaded templates
 /proc/loadCardFile(filename, directory = "strings/tcg", templates)
 	//The parser for vscode doesn't like raw strings, that's why this looks fucky
 	var/regex/template = regex("^(\[^$\\|\]+\\|)")

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -166,6 +166,8 @@ GLOBAL_PROTECT(admin_verbs_debug)
 	/client/proc/cmd_display_overlay_log,
 	/client/proc/reload_configuration,
 	/client/proc/reload_cards,
+	/client/proc/validate_cardpacks,
+	/client/proc/test_cardpack_distribution,
 	/client/proc/print_cards,
 	/datum/admins/proc/create_or_modify_area,
 	)
@@ -545,9 +547,22 @@ GLOBAL_PROTECT(admin_verbs_hideable)
 	message_admins("[key_name_admin(usr)] has  modified Dynamic Explosion Scale: [ex_scale]")
 
 /client/proc/reload_cards()
-	set name = "Reload All Cards"
+	set name = "Reload Cards"
 	set category = "Debug"
 	reloadAllCardFiles(CARD_FILES, CARD_DIRECTORY)
+
+/client/proc/validate_cardpacks()
+	set name = "Validate Cardpacks"
+	set category = "Debug"
+	checkCardpacks(CARD_PACKS)
+
+/client/proc/test_cardpack_distribution()
+	set name = "Test Cardpack Distribution"
+	set category = "Debug"
+	var/pack = input("Which pack should we test?", "You fucked it didn't you") as null|anything in sortList(CARD_PACKS)
+	var/batchCount = input("How many times should we open it?", "Don't worry, I understand") as null|num
+	var/batchSize = input("How many cards per batch?", "I hope you remember to check the validation") as null|num
+	checkCardDistribution(pack, batchSize, batchCount)
 
 /client/proc/print_cards()
 	set name = "Print Cards"

--- a/strings/tcg/templates
+++ b/strings/tcg/templates
@@ -1,2 +1,2 @@
-default|0,Coder|1,Wow, a mint condition coder card! Better tell the Github all about this!|2,icons/obj/tcg.dmi|3,runtime|4,1|5,-1|6,-1|7,S1|8,ALL|
-resin|0,Xenomorph Coder|1,Wow, a mint condition coder card! Better tell the Github all about this!|2,icons/obj/tcg_xenos.dmi|3,xeno_borg|4,2|5,-1|6,-1|7,S2|8,ALL|
+default|0,Coder|1,Wow, a mint condition coder card! Better tell the Github all about this!|2,icons/obj/tcg.dmi|3,runtime|4,1|5,-1|6,-1|7,S1|8,ALL|9,-1|
+resin|0,Xenomorph Coder|2,icons/obj/tcg_xenos.dmi|3,xeno_borg|4,2|7,S2|


### PR DESCRIPTION
I've added 2 debug verbs. 
Validate Cardpacks: which validates all the tracked cardpacks for their rarity, and makes sure all rarity indexes have at least one matching card.

Test Cardpack Distribution: which allows the user to test run cardpack openings, it allows for unlimited batches, card counts, and a choice of any of the cardpacks tracked.
It then outputs the total cards collected, and the id, name, percentage of the total, and total count for each type.

Also did a bit of cleanup with "Oh shit" alerts, and accounted for the default template in the xeno case.

Here's to the pr :)