### PR TITLE
Rework random peanuts and candy to work in place

### DIFF
--- a/code/game/objects/items/food/snacks.dm
+++ b/code/game/objects/items/food/snacks.dm
@@ -204,18 +204,24 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 2, /datum/reagent/consumable/bbqsauce = 1)
 	tastes = list("peanuts" = 2, "bbq sauce" = 1)
 
-/obj/item/random_peanuts
+/obj/item/food/peanuts/random
 	name = "\improper Parker's every-flavour peanuts"
 	desc = "What flavour will you get?"
-	icon = 'icons/obj/food/food.dmi'
 	icon_state = "peanuts"
 
-/obj/item/random_peanuts/Initialize()
-	. = ..()
-	var/random_flavour = pick(subtypesof(/obj/item/food/peanuts))
-	new random_flavour(loc)
+/obj/item/food/peanuts/random/Initialize()
+	// Generate a sample p
+	var/peanut_type = pick(subtypesof(/obj/item/food/peanuts) - /obj/item/food/peanuts/random)
+	var/obj/item/food/sample = new peanut_type(loc)
 
-	return INITIALIZE_HINT_QDEL
+	name = sample.name
+	desc = sample.desc
+	food_reagents = sample.food_reagents
+	tastes = sample.tastes
+
+	qdel(sample)
+
+	. = ..()
 
 /obj/item/food/cnds
 	name = "\improper C&Ds"
@@ -257,15 +263,20 @@
 	food_reagents = list(/datum/reagent/consumable/nutriment = 2, /datum/reagent/consumable/coco = 1, /datum/reagent/consumable/banana = 1)
 	tastes = list("chocolate candy" = 2, "banana" = 1)
 
-/obj/item/random_cnds
+/obj/item/food/cnds/random
 	name = "mystery filled C&Ds"
 	desc = "Filled with one of four delicious flavours!"
-	icon = 'icons/obj/food/food.dmi'
-	icon_state = "cnds"
 
-/obj/item/random_cnds/Initialize()
+/obj/item/food/cnds/random/Initialize()
+	var/random_flavour = pick(subtypesof(/obj/item/food/cnds) - /obj/item/food/cnds/random)
+
+	var/obj/item/food/sample = new random_flavour(loc)
+
+	name = sample.name
+	desc = sample.desc
+	food_reagents = sample.food_reagents
+	tastes = sample.tastes
+
+	qdel(sample)
+
 	. = ..()
-	var/random_flavour = pick(subtypesof(/obj/item/food/cnds))
-	new random_flavour(loc)
-
-	return INITIALIZE_HINT_QDEL

--- a/code/modules/vending/snack.dm
+++ b/code/modules/vending/snack.dm
@@ -12,9 +12,9 @@
 		            /obj/item/food/sosjerky = 6,
 					/obj/item/food/no_raisin = 6,
 					/obj/item/food/peanuts = 6,
-					/obj/item/random_peanuts = 3,
+					/obj/item/food/peanuts/random = 3,
 					/obj/item/food/cnds = 6,
-					/obj/item/random_cnds = 3,
+					/obj/item/food/cnds/random = 3,
 					/obj/item/reagent_containers/food/drinks/dry_ramen = 3,
 					/obj/item/storage/box/gum = 3,
 					/obj/item/food/energybar = 6)


### PR DESCRIPTION
Instead of creating a new item, we instead instance a temporary "flavour
sample", then copy over the name, description, flavours and reagents
before the rest of the food Initializes.