### PR TITLE
More atmos fixes - 0 Active Turfs

### DIFF
--- a/code/game/turfs/open/floor/plating/misc_plating.dm
+++ b/code/game/turfs/open/floor/plating/misc_plating.dm
@@ -93,6 +93,9 @@
 /turf/open/floor/plating/snowed/smoothed/icemoon
 	initial_gas_mix = ICEMOON_DEFAULT_ATMOS
 
+/turf/open/floor/plating/snowed/smoothed/standard_air
+	initial_gas_mix = OPENTURF_DEFAULT_ATMOS
+
 /turf/open/floor/plating/lavaland_atmos
 	planetary_atmos = TRUE
 	baseturfs = /turf/open/lava/smooth/lava_land_surface


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes all active turfs, including cursed beach turfs. Also fixes a runtiming

/turf/open/misc/asteroid/snow/standard and /turf/open/misc/asteroid/snow/standard_air may be duplicative. Not sure if the planetary atmos var is relevant. It can be dealt with later.

There is also a duplicate apc near the chapel (the art supply closet is in chapel maint area) but I'm guessing you're not done doing areas yet.